### PR TITLE
Update cl_screen.c

### DIFF
--- a/src/client/cl_screen.c
+++ b/src/client/cl_screen.c
@@ -1500,7 +1500,7 @@ SCR_UpdateScreen(void)
 	   up, or vid mode changing) do nothing at all */
 	if (cls.disable_screen)
 	{
-		if (Sys_Milliseconds() - cls.disable_screen > 120000)
+		if (Sys_Milliseconds() - cls.disable_screen > 30000)
 		{
 			cls.disable_screen = 0;
 			Com_Printf("Loading plaque timed out.\n");


### PR DESCRIPTION
Reduce showing frozen "Loading" screen from 2 minutes to 30 secs before displaying console